### PR TITLE
'func' argument of 'logMessage' compilation error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ If a console logs a **fileName.extension:123** that name turns into a clickable 
 
 That way you can either use your own logging mechanism and just add this simple prefix, e.g.
 ~~~swift
-func logMessage(message: String, filename: String = __FILE__, line: Int = __LINE__, func: String = __FUNCTION__) {
-    print("\(filename.lastPathComponent):\(line) \(func):\r\(message)")
+func logMessage(message: String, filename: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__) {
+    print("\(filename.lastPathComponent):\(line) \(function):\r\(message)")
 }
 ~~~
 


### PR DESCRIPTION
'func' argument of 'logMessage' changed to 'function' due to compilation error.
